### PR TITLE
Replace ReportVersions::Tiny with Test::ReportPrereqs

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -16,6 +16,6 @@ Dist::Zilla::Plugin::GithubMeta   = 0.12
 Dist::Zilla::Plugin::CheckExtraTests      = 0
 Dist::Zilla::Plugin::CheckPrereqsIndexed  = 0
 Dist::Zilla::Plugin::ReadmeFromPod        = 0
-Dist::Zilla::Plugin::ReportVersions::Tiny = 0
+Dist::Zilla::Plugin::Test::ReportPrereqs  = 0
 Dist::Zilla::Plugin::Test::Compile        = 0
 Dist::Zilla::Plugin::Test::ChangesHasContent = 0


### PR DESCRIPTION
`ReportVersions::Tiny` is deprecated; `Test::ReportPrereqs` is the
recommended alternative.  This change replaces the deprecated plugin with
the recommended plugin in `dist.ini`.  Although this replacement had been
made in version 0.0.5, the change in `dist.ini` had been missed which was
causing users of the bundle to still use `ReportVersions::Tiny`.  It could,
however, be possible that the issue is actually caused by the 0.0.4 version
being considered by CPAN to be the version to use rathern than the 0.0.5
version.  Nevertheless, this change, coupled with a new release, would help
many downstream users as well as close RT issue #103820.

This pull request is submitted in the hope that it is useful.  If you have any questions or comments, please don't hesitate to let me know.  If any changes are required, I can update the pull request and resubmit.
